### PR TITLE
feat(auth): add role-based login pages for admin and borrower

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,78 +1,26 @@
-import React, { useState } from "react";
-import { BookingForm } from "./components/BookingForm";
-import { BookingHistory } from "./components/BookingHistory";
-import { BookingManagementDashboard } from "./components/BookingManagementDashboard";
-import { RoomList } from "./components/RoomList";
+import React from "react";
+import { useAuth } from "./auth/AuthContext";
+import { AdminPage } from "./components/AdminPage";
+import { BorrowerPage } from "./components/BorrowerPage";
+import { LoginPage } from "./components/LoginPage";
 import "./App.css";
 
 function App() {
-  const [view, setView] = useState<
-    "rooms" | "bookingForm" | "history" | "dashboard"
-  >("rooms");
-  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+  const { user, isAuthenticated, logout } = useAuth();
 
-  function handleOpenBookingForm(roomId?: number) {
-    if (roomId) {
-      setSelectedRoomId(roomId);
-    }
-    setView("bookingForm");
+  if (!isAuthenticated || !user) {
+    return <LoginPage />;
   }
 
-  return (
-    <div className="App">
-      <header className="App-header">
-        <div className="App-header-inner">
-          <h1 className="App-title">Room Booking System</h1>
-          <nav className="App-nav" aria-label="Primary">
-            <button
-              type="button"
-              className={`App-nav-button ${view === "rooms" ? "active" : ""}`}
-              onClick={() => setView("rooms")}
-            >
-              Rooms
-            </button>
-            <button
-              type="button"
-              className={`App-nav-button ${
-                view === "bookingForm" ? "active" : ""
-              }`}
-              onClick={() => handleOpenBookingForm()}
-            >
-              Booking Form
-            </button>
-            <button
-              type="button"
-              className={`App-nav-button ${view === "history" ? "active" : ""}`}
-              onClick={() => setView("history")}
-            >
-              Booking History
-            </button>
-            <button
-              type="button"
-              className={`App-nav-button ${
-                view === "dashboard" ? "active" : ""
-              }`}
-              onClick={() => setView("dashboard")}
-            >
-              Booking Dashboard
-            </button>
-          </nav>
-        </div>
-      </header>
-      <main className="App-main">
-        {view === "rooms" && <RoomList onBookRoom={handleOpenBookingForm} />}
-        {view === "bookingForm" && (
-          <BookingForm
-            preselectedRoomId={selectedRoomId}
-            onCancel={() => setView("rooms")}
-            onSuccess={() => setView("dashboard")}
-          />
-        )}
-        {view === "history" && <BookingHistory />}
-        {view === "dashboard" && <BookingManagementDashboard />}
-      </main>
-    </div>
-  );
+  if (user.role === "Admin") {
+    return <AdminPage displayName={user.displayName} onLogout={logout} />;
+  }
+
+  if (user.role === "Peminjam") {
+    return <BorrowerPage displayName={user.displayName} onLogout={logout} />;
+  }
+
+  return <LoginPage />;
 }
 
 export default App;

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,0 +1,87 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+import {
+  apiService,
+  LoginRequest,
+  LoginResponse,
+  UserRole,
+} from "../services/api";
+
+const AUTH_STORAGE_KEY = "room_booking_auth";
+
+export type AuthUser = {
+  username: string;
+  displayName: string;
+  role: UserRole;
+  token: string;
+  expiresAt: number;
+};
+
+type AuthContextType = {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  login: (payload: LoginRequest) => Promise<void>;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+function mapLoginResponse(response: LoginResponse): AuthUser {
+  return {
+    username: response.username,
+    displayName: response.displayName,
+    role: response.role,
+    token: response.token,
+    expiresAt: Date.now() + response.expiresInSeconds * 1000,
+  };
+}
+
+function loadStoredAuth(): AuthUser | null {
+  const raw = localStorage.getItem(AUTH_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as AuthUser;
+    if (!parsed.token || Date.now() >= parsed.expiresAt) {
+      localStorage.removeItem(AUTH_STORAGE_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    localStorage.removeItem(AUTH_STORAGE_KEY);
+    return null;
+  }
+}
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [user, setUser] = useState<AuthUser | null>(() => loadStoredAuth());
+
+  const value = useMemo<AuthContextType>(
+    () => ({
+      user,
+      isAuthenticated: !!user,
+      login: async (payload) => {
+        const response = await apiService.login(payload);
+        const mapped = mapLoginResponse(response);
+        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(mapped));
+        setUser(mapped);
+      },
+      logout: () => {
+        localStorage.removeItem(AUTH_STORAGE_KEY);
+        setUser(null);
+      },
+    }),
+    [user],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used inside AuthProvider");
+  }
+  return context;
+}

--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { BookingHistory } from "./BookingHistory";
+import { BookingManagementDashboard } from "./BookingManagementDashboard";
+import { RoomList } from "./RoomList";
+
+type AdminView = "dashboard" | "rooms" | "history";
+
+type AdminPageProps = {
+  displayName: string;
+  onLogout: () => void;
+};
+
+export const AdminPage: React.FC<AdminPageProps> = ({
+  displayName,
+  onLogout,
+}) => {
+  const [view, setView] = useState<AdminView>("dashboard");
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <div className="App-header-inner">
+          <h1 className="App-title">Admin Panel - {displayName}</h1>
+          <nav className="App-nav" aria-label="Admin Navigation">
+            <button
+              type="button"
+              className={`App-nav-button ${view === "dashboard" ? "active" : ""}`}
+              onClick={() => setView("dashboard")}
+            >
+              Dashboard
+            </button>
+            <button
+              type="button"
+              className={`App-nav-button ${view === "rooms" ? "active" : ""}`}
+              onClick={() => setView("rooms")}
+            >
+              Rooms
+            </button>
+            <button
+              type="button"
+              className={`App-nav-button ${view === "history" ? "active" : ""}`}
+              onClick={() => setView("history")}
+            >
+              Booking History
+            </button>
+            <button type="button" className="App-nav-button" onClick={onLogout}>
+              Logout
+            </button>
+          </nav>
+        </div>
+      </header>
+
+      <main className="App-main">
+        {view === "dashboard" && <BookingManagementDashboard />}
+        {view === "rooms" && <RoomList />}
+        {view === "history" && <BookingHistory />}
+      </main>
+    </div>
+  );
+};

--- a/src/components/BorrowerPage.tsx
+++ b/src/components/BorrowerPage.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { BookingForm } from "./BookingForm";
+import { BookingHistory } from "./BookingHistory";
+import { RoomList } from "./RoomList";
+
+type BorrowerView = "rooms" | "bookingForm" | "history";
+
+type BorrowerPageProps = {
+  displayName: string;
+  onLogout: () => void;
+};
+
+export const BorrowerPage: React.FC<BorrowerPageProps> = ({
+  displayName,
+  onLogout,
+}) => {
+  const [view, setView] = useState<BorrowerView>("rooms");
+  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+
+  function handleOpenBookingForm(roomId?: number) {
+    if (roomId) {
+      setSelectedRoomId(roomId);
+    }
+    setView("bookingForm");
+  }
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <div className="App-header-inner">
+          <h1 className="App-title">Portal Peminjam - {displayName}</h1>
+          <nav className="App-nav" aria-label="Borrower Navigation">
+            <button
+              type="button"
+              className={`App-nav-button ${view === "rooms" ? "active" : ""}`}
+              onClick={() => setView("rooms")}
+            >
+              Rooms
+            </button>
+            <button
+              type="button"
+              className={`App-nav-button ${view === "bookingForm" ? "active" : ""}`}
+              onClick={() => handleOpenBookingForm()}
+            >
+              Booking Form
+            </button>
+            <button
+              type="button"
+              className={`App-nav-button ${view === "history" ? "active" : ""}`}
+              onClick={() => setView("history")}
+            >
+              Booking History
+            </button>
+            <button type="button" className="App-nav-button" onClick={onLogout}>
+              Logout
+            </button>
+          </nav>
+        </div>
+      </header>
+
+      <main className="App-main">
+        {view === "rooms" && <RoomList onBookRoom={handleOpenBookingForm} />}
+        {view === "bookingForm" && (
+          <BookingForm
+            preselectedRoomId={selectedRoomId}
+            onCancel={() => setView("rooms")}
+            onSuccess={() => setView("history")}
+          />
+        )}
+        {view === "history" && <BookingHistory />}
+      </main>
+    </div>
+  );
+};

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { useAuth } from "../auth/AuthContext";
+import "../styles/LoginPage.css";
+
+export const LoginPage: React.FC = () => {
+  const { login } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!username.trim() || !password.trim()) {
+      setError("Username dan password wajib diisi.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await login({ username: username.trim(), password });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Login gagal");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <h1>Login Room Booking</h1>
+        <p>Masuk sebagai Admin atau Peminjam.</p>
+
+        {error && <div className="login-error">{error}</div>}
+
+        <form onSubmit={onSubmit} className="login-form">
+          <label htmlFor="username">Username</label>
+          <input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="admin / peminjam"
+          />
+
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Masukkan password"
+          />
+
+          <button type="submit" disabled={loading}>
+            {loading ? "Memproses..." : "Login"}
+          </button>
+        </form>
+
+        <div className="login-hint">
+          <strong>Demo akun:</strong>
+          <div>Admin: admin / admin123</div>
+          <div>Peminjam: peminjam / peminjam123</div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import { AuthProvider } from "./auth/AuthContext";
+import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,21 @@
 const API_BASE_URL =
   process.env.REACT_APP_API_URL || "http://localhost:5271/api";
 
+export type UserRole = "Admin" | "Peminjam";
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  username: string;
+  displayName: string;
+  role: UserRole;
+  expiresInSeconds: number;
+}
+
 export interface Room {
   id: number;
   roomNumber: string;
@@ -35,13 +50,28 @@ export interface PaginatedResponse<T> {
 }
 
 class ApiService {
+  private getStoredToken(): string | null {
+    const raw = localStorage.getItem("room_booking_auth");
+    if (!raw) return null;
+
+    try {
+      const parsed = JSON.parse(raw) as { token?: string };
+      return parsed.token ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private async request<T>(
     endpoint: string,
     options?: RequestInit,
   ): Promise<T> {
+    const token = this.getStoredToken();
+
     const response = await fetch(`${API_BASE_URL}${endpoint}`, {
       headers: {
         "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...options?.headers,
       },
       ...options,
@@ -55,6 +85,16 @@ class ApiService {
     }
 
     return response.json();
+  }
+
+  async login(payload: LoginRequest): Promise<LoginResponse> {
+    return this.request<LoginResponse>("/auth/login", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
   }
 
   // Room endpoints

--- a/src/styles/LoginPage.css
+++ b/src/styles/LoginPage.css
@@ -1,0 +1,79 @@
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(160deg, #1f2937, #374151);
+  padding: 20px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+  background: #ffffff;
+  border-radius: 14px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  padding: 22px;
+  text-align: left;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.login-card p {
+  margin: 8px 0 14px;
+  color: #666;
+}
+
+.login-error {
+  background: #fff1f1;
+  border: 1px solid #ffc8c8;
+  color: #9b1c1c;
+  border-radius: 10px;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.login-form input {
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  padding: 10px 12px;
+  outline: none;
+}
+
+.login-form input:focus {
+  border-color: #61dafb;
+  box-shadow: 0 0 0 3px rgba(97, 218, 251, 0.25);
+}
+
+.login-form button {
+  margin-top: 8px;
+  border: 1px solid #282c34;
+  background: #282c34;
+  color: white;
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.login-form button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.login-hint {
+  margin-top: 14px;
+  background: #f7fafc;
+  border-radius: 10px;
+  padding: 10px;
+  font-size: 13px;
+  color: #333;
+}


### PR DESCRIPTION
Closes #9 

## Summary
This PR implements frontend authentication flow with role-based UI rendering for `Admin` and `Peminjam`.

## Changes
- Added `AuthContext` for auth state management
- Added login page UI and login flow
- Added role-based pages:
  - `AdminPage`
  - `BorrowerPage`
- Updated app root rendering to guard views by role
- Added logout flow and local session persistence
- Updated API service:
  - login request support
  - automatic `Authorization: Bearer <token>` header on requests
- Wrapped app with `AuthProvider` in `index.tsx`

## Access Rules
- Admin users can access admin page/menu
- Borrower users cannot access admin page/menu
- Unauthenticated users are redirected to login page

## Validation
- Frontend build passes (`npm run build`)
- Login success stores token and user role
- Logout clears auth session and returns to login